### PR TITLE
0.2.1 Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,15 @@ clean-pyc:
 
 clean: clean-build clean-pyc clean-docs
 
-dist: test docs clean
+dist: test clean
 	python setup.py sdist
 	python setup.py bdist_wheel
 
 release: clean
-	python setup.py sdist upload
-	python setup.py bdist_wheel upload
+	python setup.py sdist
+	python setup.py bdist_wheel
+	pip install twine
+	twine upload dist/*
 
 install: clean
 	python setup.py install

--- a/coinmetrics/utils.py
+++ b/coinmetrics/utils.py
@@ -26,6 +26,7 @@ def cm_to_pandas(data):
         pandas_dataframe = pd.DataFrame(index=raw_index,
                                         data=raw_values,
                                         columns=data['metrics'])
+        pandas_dataframe = pandas_dataframe.astype(float)
         return pandas_dataframe
     return data
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2019, Robert Rice'
 author = 'Robert Rice'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.0'
+release = '0.2.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt') as f:
 
 setup(
 	name='coinmetrics',
-	version='0.2.0',
+	version='0.2.1',
 	author="Robert Rice",
 	author_email="h4110w33n@gmail.com",
 	url='https://github.com/h4110w33n/coinmetrics',


### PR DESCRIPTION
This update is almost completely "behind the scenes changes" that just needed to be done, and simply weren't done in the original v2 release.
* The `Makefile` now has a completed `release` target that will upload the package to PyPi. I intend for it to handle some of the `git` tagging in a future update.
* The Pandas DataFrame conversion will now make an attempt to convert everything to a numeric type. This didn't affect the CSV saving/loading process since it is all cast as strings, but leaving strings in the DataFrame meant that serial API call then processing (in a single script) caused type errors. 